### PR TITLE
Schema: Fixed metadataLastUpdated capitalization in date object

### DIFF
--- a/code.json
+++ b/code.json
@@ -48,7 +48,7 @@
   "date": {
     "created": "2025-02-04T21:59:53Z",
     "lastModified": "2025-08-13T22:27:54Z",
-    "metaDataLastUpdated": "2025-08-15T16:41:02.063Z"
+    "metadataLastUpdated": "2025-08-15T16:41:02.063Z"
   },
   "tags": [
     "dsacms-tier3",

--- a/schemas/cms/schema-2.0.0.json
+++ b/schemas/cms/schema-2.0.0.json
@@ -344,7 +344,7 @@
                     "format": "date-time",
                     "description": "Date when the project was last modified"
                 },
-                "metaDataLastUpdated": {
+                "metadataLastUpdated": {
                     "type": "string",
                     "format": "date-time",
                     "description": "Date when metadata was last updated"

--- a/schemas/schema-2.0.0.json
+++ b/schemas/schema-2.0.0.json
@@ -283,7 +283,7 @@
                     "format": "date-time",
                     "description": "Date when the project was last modified"
                 },
-                "metaDataLastUpdated": {
+                "metadataLastUpdated": {
                     "type": "string",
                     "format": "date-time",
                     "description": "Date when metadata was last updated"

--- a/tests/examples/codejson-example-dedupliFHIR.json
+++ b/tests/examples/codejson-example-dedupliFHIR.json
@@ -50,7 +50,7 @@
     "date": {
         "created": "2023-06-22T17:08:19Z",
         "lastModified": "2025-02-13T18:44:26Z",
-        "metaDataLastUpdated": "2025-06-10T14:55:32.836Z"
+        "metadataLastUpdated": "2025-06-10T14:55:32.836Z"
     },
     "tags": [
         "AI",

--- a/tests/examples/codejson-example-metrics.json
+++ b/tests/examples/codejson-example-metrics.json
@@ -47,7 +47,7 @@
     "date": {
         "created": "2023-07-18T14:10:58Z",
         "lastModified": "2025-06-01T11:36:12Z",
-        "metaDataLastUpdated": "2025-06-06T16:36:38.949Z"
+        "metadataLastUpdated": "2025-06-06T16:36:38.949Z"
     },
     "tags": [
         "metrics",


### PR DESCRIPTION
## Problem
Identified incorrect capitalization of property in date object: `metaDataLastUpdated`

## Solution
- Updated field to be `metadataLastUpdated`
- Schemas and tests are updated accordingly

## Test Plan
Tests pass