### PR TITLE
CMS Schema: Add new enum option to repositoryHost & update docs 

### DIFF
--- a/.github/workflows/json-schema-tests.yml
+++ b/.github/workflows/json-schema-tests.yml
@@ -35,4 +35,4 @@ jobs:
         run: jsonschema test tests/gov-schema.json --resolve schemas/schema-2.0.0.json
       
       - name: Run CMS schema unit tests
-        run: jsonschema test tests/cms-schema.json --resolve schemas/cms/schema-2.0.0.json
+        run: jsonschema test tests/cms-schema.json --resolve schemas/cms/schema-2.1.0.json

--- a/docs/metadata.md
+++ b/docs/metadata.md
@@ -835,7 +835,10 @@ Full schema can be found in [schema-2.0.0.json](../schemas/schema-2.0.0.json).
         - policy<br>
         - operational<br>
         - medicare<br>
-        - medicaid
+        - medicaid<br>
+        - SNAP<br>
+        - TANF<br>
+        - human-benefit-services
       </td>
     </tr>
     <tr>
@@ -847,7 +850,10 @@ Full schema can be found in [schema-2.0.0.json](../schemas/schema-2.0.0.json).
       <td>
         - providers<br>
         - patients<br>
-        - government
+        - government<br>
+        - applicants<br>
+        - beneficiaries<br>
+        - enrollees
       </td>
     </tr>
     <tr>

--- a/docs/metadata.md
+++ b/docs/metadata.md
@@ -520,6 +520,7 @@ Full schema can be found in [schema-2.0.0.json](../schemas/schema-2.0.0.json).
         - github.com/CMS-Enterprise<br>
         - github.com/Enterprise-CMCS<br>
         - github.com/DSACMS<br>
+        - github.com/MeasureAuthoringTool<br>
         - github.cms.gov<br>
         - CCSQ GitHub
       </td>

--- a/docs/metadata.md
+++ b/docs/metadata.md
@@ -867,7 +867,7 @@ Full schema can be found in [schema-2.0.0.json](../schemas/schema-2.0.0.json).
   </tbody>
 </table>
 
-Full schema can be found in [schema-0.2.0.json](../schemas/cms/schema-0.2.0.json).
+Full schema can be found in [schema-2.1.0.json](../schemas/cms/schema-2.1.0.json).
 
 ### Adding new metadata fields
 

--- a/schemas/cms/schema-2.1.0.json
+++ b/schemas/cms/schema-2.1.0.json
@@ -137,6 +137,7 @@
                 "github.com/CMS-Enterprise",
                 "github.com/Enterprise-CMCS",
                 "github.com/DSACMS",
+                "github.com/MeasureAuthoringTool",
                 "github.cms.gov",
                 "CCSQ GitHub"
             ]


### PR DESCRIPTION
## Problem
Currently, `repositoryHost` field does not support repository that live under github.com/MeasureAuthoringTool.

Additionally, we would like to update the docs to align with additions from this PR #46 

## Solution
- Add an enum option to `repositoryHost`: `github.com/MeasureAuthoringTool`
- Update metadata.md to reflect the latest updates in v2.1.0 CMS schema

## Result
Closes #49 

## Test
All checks pass